### PR TITLE
Fix bug and buffer overrun in modbusExchangeRegisters

### DIFF
--- a/yaMBSiavr.c
+++ b/yaMBSiavr.c
@@ -319,7 +319,7 @@ uint8_t modbusExchangeRegisters(volatile uint16_t *ptrToInArray, uint16_t startA
 			if ((requestedAmount*2)<=(MaxFrameIndex-4)) //message buffer big enough?
 			{
 				rxbuffer[2]=(unsigned char)(requestedAmount*2);
-				intToModbusRegister(ptrToInArray+(unsigned char)(requestedAdr-startAddress),rxbuffer+3,rxbuffer[2]);
+				intToModbusRegister(ptrToInArray+(unsigned char)(requestedAdr-startAddress),rxbuffer+3,requestedAmount);
 				modbusSendMessage(2+rxbuffer[2]);
 				return 1;
 			} else modbusSendException(ecIllegalDataValue);


### PR DESCRIPTION
The third argument function intToModbusRegisters is a number of modbus
registers, while the call in modbusExchangeRegisters provided the
number of bytes instead. With an rxbuffer of 256 bytes, reading 64
registers or more would lead to a buffer overrun.