### PR TITLE
Support for Device Identification

### DIFF
--- a/example/example.c
+++ b/example/example.c
@@ -116,6 +116,10 @@ void modbusGet(void) {
 				modbusExchangeRegisters(holdingRegisters,0,4);
 			}
 			break;
+			case fcEncapsulatedInterfaceTransport:
+			{
+				modbusHandleDeviceId();
+			}
 			
 			default: {
 				modbusSendException(ecIllegalFunction);

--- a/yaMBSiavr.h
+++ b/yaMBSiavr.h
@@ -55,6 +55,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #define BAUD 38400L
 #endif
 
+#define MODBUS_DEV_VENDOR "Your Company"
+#define MODBUS_DEV_PRODUCT "Your Device Name"
+#define MODBUS_DEV_VERSION "V0.1beta"
+
 /*
 * Definitions for transceiver enable pin.
 */
@@ -256,6 +260,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #define fcForceMultipleCoils 15 //write multiple bits
 #define fcPresetMultipleRegisters 16 //write multiple analog output registers (2 Bytes each)
 #define fcReportSlaveID 17 //read device description, run status and other device specific information
+#define fcEncapsulatedInterfaceTransport 43 //device identification
 
 /**
  * @brief    Modbus Exception Codes
@@ -381,6 +386,8 @@ extern uint8_t modbusExchangeBits(volatile uint8_t *ptrToInArray, uint16_t start
 */
 extern uint8_t modbusExchangeRegisters(volatile uint16_t *ptrToInArray, uint16_t startAddress, uint16_t size);
 
+uint8_t modbusExchangeString(volatile char* str, uint8_t size);
+
 /* @brief: returns 1 if data location adr is touched by current command
 *
 *         Arguments: - adr: address of the data object
@@ -398,4 +405,6 @@ extern uint8_t modbusIsRangeInRange(uint16_t startAdr, uint16_t lastAdr);
 
 extern volatile uint16_t modbusDataAmount;
 extern volatile uint16_t modbusDataLocation;
+
+void modbusHandleDeviceId();
 #endif

--- a/yaMBSiavr.h
+++ b/yaMBSiavr.h
@@ -38,6 +38,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
     
 ************************************************************************/
 #include <avr/io.h>
+#include <avr/pgmspace.h>
 /** 
  *  @code #include <yaMBSIavr.h> @endcode
  * 
@@ -54,6 +55,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef BAUD
 #define BAUD 38400L
 #endif
+
+#define MODBUS_DEV_VENDOR "Your Company"
+#define MODBUS_DEV_PRODUCT "Your Device Name"
+#define MODBUS_DEV_VERSION "V0.1beta"
 
 /*
 * Definitions for transceiver enable pin.
@@ -256,6 +261,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #define fcForceMultipleCoils 15 //write multiple bits
 #define fcPresetMultipleRegisters 16 //write multiple analog output registers (2 Bytes each)
 #define fcReportSlaveID 17 //read device description, run status and other device specific information
+#define fcEncapsulatedInterfaceTransport 43 //device identification
 
 /**
  * @brief    Modbus Exception Codes
@@ -381,6 +387,8 @@ extern uint8_t modbusExchangeBits(volatile uint8_t *ptrToInArray, uint16_t start
 */
 extern uint8_t modbusExchangeRegisters(volatile uint16_t *ptrToInArray, uint16_t startAddress, uint16_t size);
 
+uint8_t modbusExchangeString(volatile char* str, uint8_t size);
+
 /* @brief: returns 1 if data location adr is touched by current command
 *
 *         Arguments: - adr: address of the data object
@@ -398,4 +406,6 @@ extern uint8_t modbusIsRangeInRange(uint16_t startAdr, uint16_t lastAdr);
 
 extern volatile uint16_t modbusDataAmount;
 extern volatile uint16_t modbusDataLocation;
+
+void modbusHandleDeviceId();
 #endif


### PR DESCRIPTION
Added support for Device identification (vendor, product, version), information is stored in flash and can be read with std functionality e.g. from pymodbus:
![grafik](https://github.com/mbs38/yaMBSiavr/assets/73906153/17e950d0-e399-4d7c-9232-ddb3c08ae69c)
